### PR TITLE
ngModel triggers change and blur events to properly handle materilize animations

### DIFF
--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -1,6 +1,23 @@
 (function (angular) {
     angular.module("ui.materialize", ["ui.materialize.toast", "ui.materialize.sidenav", "ui.materialize.material_select", "ui.materialize.dropdown", "ui.materialize.inputfield", "ui.materialize.input_date", "ui.materialize.tabs", "ui.materialize.pagination"]);
 
+    angular.module('ui.materialize').directive("ngModel",function(){
+        return {
+            restrict: 'A',
+            priority: -1, // lower priority than built-in ng-model so it runs first
+            link: function(scope, element, attr) {
+                scope.$watch(attr.ngModel,function(value){
+                    if (value){
+                        element.trigger("change");
+                    } else if(value === undefined && element.attr('placeholder') === undefined) {
+                        if(!element.is(":focus"))
+                            element.trigger("blur");
+                    }
+                });
+            }
+        }
+    });
+
     angular.module("ui.materialize.toast", [])
         .constant("toastConfig", {
             duration: 3000,


### PR DESCRIPTION
When a ngModel value changed the input wasn't triggering animation on inputs, I extended the directive to trigger "change" and "blur" events on the input the aren't focused.
