### PR TITLE
Use Materialize.updateTextFields instead of firing a change event to preserve ng-pristine.

### DIFF
--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -185,7 +185,7 @@
                 scope: {},
                 link: function (scope, element) {
                     $timeout(function () {
-                        angular.element(element).find("input").change();
+                        Materialize.updateTextFields();
                     });
                 },
                 template: '<div ng-transclude class="input-field"></div>'


### PR DESCRIPTION
This pull request fixes https://github.com/krescruz/angular-materialize/issues/24 .

Firing a change event is causing AngularJS to change the class from `ng-pristine` to `ng-dirty`.  This is problematic for people who want to do form validations that include `ng-pristine`.

It looks like there is a method `Materialize.updateTextFields()` that does the animation and still preserves `ng-pristine`.
