### PR TITLE
Add a $watch to material-select so it responds to $scope changes.

### DIFF
--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -122,6 +122,11 @@
                         $timeout(function () {
                             element.material_select();
                         });
+                        if (attrs.ngModel) {
+                            scope.$watch(attrs.ngModel, function() {
+                                element.material_select();
+                            });
+                        }
                     }
                 }
             };


### PR DESCRIPTION
`SELECT`s that use `material-select` do not currently respond to `$scope` changes.  This commit adds a `$watch` so that any changes on the `$scope` are reflected in the GUI component.
