### PR TITLE
Fixed modal directive.

### DIFF
--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -695,10 +695,10 @@
         .directive("modal", ["$compile", "$timeout", function ($compile, $timeout) {
             return {
                 scope: {
-                    dismissible: "@",
+                    dismissible: "=",
                     opacity: "@",
-                    in_duration: "@",
-                    out_duration: "@"
+                    inDuration: "@",
+                    outDuration: "@"
                 },
                 link: function (scope, element, attrs) {
                     $compile(element.contents())(scope);
@@ -706,8 +706,8 @@
                         element.leanModal({
                             dismissible: (angular.isDefined(scope.dismissible)) ? scope.dismissible : undefined,
                             opacity: (angular.isDefined(scope.opacity)) ? scope.opacity : undefined,
-                            in_duration: (angular.isDefined(scope.in_duration)) ? scope.in_duration : undefined,
-                            out_duration: (angular.isDefined(scope.out_duration)) ? scope.out_duration : undefined
+                            in_duration: (angular.isDefined(scope.inDuration)) ? scope.inDuration : undefined,
+                            out_duration: (angular.isDefined(scope.outDuration)) ? scope.outDuration : undefined
                         });
                     });
                 }


### PR DESCRIPTION
The value of dismissible needs to be passed as boolean, so the ‘@‘ should be replaced
by ‘=‘.
in_duration and out_duration need to be converted to camelCase in
directive.

Fixed Example:

``` html
<a href=“#demoModal” modal data-dismissible="false" in-duration="500"
out_duration="200”>
```

For in_duration and out_duration both dash and underscore are accepted.
