### PR TITLE
Fixed the bug of updating current page object of pagination and enabled ulClass

### DIFF
--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -648,7 +648,7 @@
             return {
                 restrict: 'EA',
                 scope: {
-                    page: '@',
+                    page: '=',
                     pageSize: '@',
                     total: '@',
                     dots: '@',

--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -420,7 +420,10 @@
         page="1"
         page-size="10"
         total="100"
-        pagination-action="changePage(page)">
+        pagination-action="changePage(page)"
+        ul-class="customClass">
+
+     * ul-class could be either an object or a string
      */
     angular.module("ui.materialize.pagination", [])
         .directive('pagination', function () {
@@ -432,7 +435,7 @@
                 scope.page = parseInt(scope.page) || 1;
                 scope.total = parseInt(scope.total) || 0;
                 scope.dots = scope.dots || '...';
-                scope.ulClass = 'pagination';
+                scope.ulClass = scope.ulClass || attrs.ulClass || 'pagination';
                 scope.adjacent = parseInt(scope.adjacent) || 2;
                 scope.activeClass = 'active';
                 scope.disabledClass = 'disabled';
@@ -652,7 +655,8 @@
                     hideIfEmpty: '@',
                     adjacent: '@',
                     scrollTop: '@',
-                    paginationAction: '&'
+                    paginationAction: '&',
+                    ulClass: '='
                 },
                 template:
                     '<ul ng-hide="Hide" ng-class="ulClass"> ' +


### PR DESCRIPTION
# Fixed the bug of updating current page object of pagination

I believe the directive should update the current page object which is
passed via page attribute. I replaced ‘@‘ by ‘=‘.
# Enabled ulClass to be customisable

I think it would be useful if ulClass can be customised.
I updated the directive, now the ulClass can be passed as an object or
a string. The default class is ‘pagination’.

Example:
Pass object via ul-class :

``` html
<pagination ul-class=“{‘pagination pagination-venter’: condition, ‘pagination pagination-left’: !condition}”>
```

Pass string via ul-class:
(Only one class acceptable)

``` html
<pagination ul-class=“customClass”>
```

Pass multiple classes via ul-class:
(This has to be passed as a string object)

``` javascript
// in controller:
$scope.customClass = 'class-1 class-2 class-3';
```

``` html
<pagination ul-class=“customClass”>
```
