### PR TITLE
should depend on materialize

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,5 +7,8 @@
     "index.html",
     "Gruntfile.js",
     "package.json"
-  ]
+  ],
+  "dependencies": {
+    "materialize": "~0.97.0"
+  }
 }


### PR DESCRIPTION
Since this library is based on materialize, it should be listed as a dependency. Which is standard practice for bower and npm. Also, it helps with libraries such as `gulp-wiredep` to know what should be included before the current scripts. But I am sure there are other reasons as well.
