### PR TITLE
Fixed dropdown and pagination

### DIFF
--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -195,7 +195,9 @@
                     belowOrigin: "@"
                 },
                 link: function (scope, element, attrs) {
-                    $compile(element.contents())(scope);
+                    $timeout(function() {
+                        $compile(element.contents())(scope);
+                    });
                     $timeout(function () {
                         element.dropdown({
                             inDuration: (angular.isDefined(scope.inDuration)) ? scope.inDuration : undefined,
@@ -697,7 +699,7 @@
                     adjacent: '@',
                     scrollTop: '@',
                     paginationAction: '&',
-                    ulClass: '@'
+                    ulClass: '='
                 },
                 template:
                     '<ul ng-hide="Hide" ng-class="ulClass"> ' +

--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -195,10 +195,8 @@
                     belowOrigin: "@"
                 },
                 link: function (scope, element, attrs) {
-                    $timeout(function() {
-                        $compile(element.contents())(scope);
-                    });
                     $timeout(function () {
+                        $compile(element.contents())(scope);
                         element.dropdown({
                             inDuration: (angular.isDefined(scope.inDuration)) ? scope.inDuration : undefined,
                             outDuration: (angular.isDefined(scope.outDuration)) ? scope.outDuration : undefined,
@@ -699,7 +697,7 @@
                     adjacent: '@',
                     scrollTop: '@',
                     paginationAction: '&',
-                    ulClass: '='
+                    ulClass: '=?'
                 },
                 template:
                     '<ul ng-hide="Hide" ng-class="ulClass"> ' +


### PR DESCRIPTION
Fixed initialisation of dynamic content in drop down. it had an issue
when rendering dynamic content in drop down.
e.g.

``` HTML
<a class='dropdown-button btn' href='javascript:void(0);'
data-activates='demoDropdown' dropdown data-hover="true">
    {{ dynamic_content }}
</a>
```

it renders nothing initially. I moved $compile inside $timeout to fix the
issue.
## 

Fixed ulClass of pagination. Now the directive accepts object, string.
ulClass is not mandatory.
