### PR TITLE
Added index to be required as module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,37 @@ angular-materialize
 
 **angular-materialize** in action http://krescruz.github.io/angular-materialize/
 
-This library is a set of AngularJS directives which make it possible to use features from [Materialize](http://materializecss.com/) with AngularJS. 
+This library is a set of AngularJS directives which make it possible to use features from [Materialize](http://materializecss.com/) with AngularJS.
 
-Just add the module ui.materialize to your dependencies like: 
+Just add the module ui.materialize to your dependencies like:
 
     angular.module('angular-app', [
       'ui.materialize'
     ])
-    
-and then you are good to go. 
 
-This is not to be confused with the [Angular Material](https://material.angularjs.org/) project, which is a standalone Material design implementation for AngularJS. 
+and then you are good to go.
 
-We are on Bower, look for [`angular-materialize`](http://bower.io/search/?q=angular-materialize). 
+This is not to be confused with the [Angular Material](https://material.angularjs.org/) project, which is a standalone Material design implementation for AngularJS.
 
+We are on Bower, look for [`angular-materialize`](http://bower.io/search/?q=angular-materialize).
+or in NPM, look for [`angular-materialize`](https://www.npmjs.com/package/angular-materialize).
 
+##### Use with Webpack
+Angular looks for jQuery and if no exists, it uses jQlite. Some directives of `angular-materialize` uses some jQuery methods, so be sure that Angular uses it instead of jQlite. It can be done by adding the following lines in your config.
+```javascript
+//webpack.config.js
+plugins: [
+    new webpack.ProvidePlugin({
+      'window.jQuery': 'jquery'
+    })
+  ],
+```
+then simply add to your module:
+```javascript
+// yourModule.js
+// ES6 style
+import angularMaterialize from 'angular-materialize';
+// OR commonjs style
+var angularMaterialize = require('angular-materialize');
+angular.module('yourModule', [angularMaterialize]);
+```

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,2 @@
-var fs = require('fs');
-var vm = require('vm');
-
-module.exports.bind = function (angular, jquery) {
-  var context = {'angular': angular, '$': jquery};
-  var src = fs.readFileSync(__dirname + '/angular-materialize.js', 'utf8');
-  vm.runInNewContext(src, context);
-  return context;
-};
+require('./angular-materialize');
+module.exports = 'ui.materialize';


### PR DESCRIPTION
Hi, first of all, thanks for this good job migrating some JS components to Angular. 

Im working with Webpack right now and noticed that when requiring the angular-materialize had some issues, so i solved them with these changes BUT they affects to the package.json config, so i will try to get both configs working together later. I hope to get some help from you with this as i dont know whats the finality of the src/index.js yet.
Will be great if this is published into NPM too for many others (like me) in the near future :)

Regards! 
