### PR TITLE
Attempt to fix #114 - open close modal from controller

### DIFF
--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -838,16 +838,27 @@
                     dismissible: "=",
                     opacity: "@",
                     inDuration: "@",
-                    outDuration: "@"
+                    outDuration: "@",
+                    ready: '&?',
+                    complete: '&?',
+                    open: '='
                 },
                 link: function (scope, element, attrs) {
                     $timeout(function () {
+                        var modalEl = $('#' + attrs.target);
                         $compile(element.contents())(scope);
                         element.leanModal({
                             dismissible: (angular.isDefined(scope.dismissible)) ? scope.dismissible : undefined,
                             opacity: (angular.isDefined(scope.opacity)) ? scope.opacity : undefined,
                             in_duration: (angular.isDefined(scope.inDuration)) ? scope.inDuration : undefined,
-                            out_duration: (angular.isDefined(scope.outDuration)) ? scope.outDuration : undefined
+                            out_duration: (angular.isDefined(scope.outDuration)) ? scope.outDuration : undefined,
+                            ready: (angular.isDefined(scope.ready)) ? function() {scope.$eval(scope.ready())} : undefined,
+                            complete: (angular.isDefined(scope.complete)) ? function() {scope.$eval(scope.complete())} : undefined,
+                        });
+
+                        scope.$watch('open', function(value, lastValue) {
+                          if (!angular.isDefined(value)) { return; }
+                          (value === true) ? modalEl.openModal() : modalEl.closeModal();
                         });
                     });
                 }

--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -856,10 +856,12 @@
                             complete: (angular.isDefined(scope.complete)) ? function() {scope.$eval(scope.complete())} : undefined,
                         });
 
-                        scope.$watch('open', function(value, lastValue) {
-                          if (!angular.isDefined(value)) { return; }
-                          (value === true) ? modalEl.openModal() : modalEl.closeModal();
-                        });
+                        if (angular.isDefined(attrs.open)) {
+                          scope.$watch('open', function(value, lastValue) {
+                            if (!angular.isDefined(value)) { return; }
+                            (value === true) ? modalEl.openModal() : modalEl.closeModal();
+                          });
+                        }
                     });
                 }
             };

--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -845,7 +845,7 @@
                 },
                 link: function (scope, element, attrs) {
                     $timeout(function () {
-                        var modalEl = $('#' + attrs.target);
+                        var modalEl = $(attrs.href ? attrs.href : '#' + attrs.target);
                         $compile(element.contents())(scope);
                         element.leanModal({
                             dismissible: (angular.isDefined(scope.dismissible)) ? scope.dismissible : undefined,
@@ -856,7 +856,7 @@
                             complete: (angular.isDefined(scope.complete)) ? function() {scope.$eval(scope.complete())} : undefined,
                         });
 
-                        if (angular.isDefined(attrs.open)) {
+                        if (angular.isDefined(attrs.open) && modalEl.length > 0) {
                           scope.$watch('open', function(value, lastValue) {
                             if (!angular.isDefined(value)) { return; }
                             (value === true) ? modalEl.openModal() : modalEl.closeModal();


### PR DESCRIPTION
Also adds ability to add a ready or complete callback to know when the modal has been opened (ready) or closed (complete). The way you can open or close a modal is by changing the value of the open boolean you pass into the modal trigger directive. For example if you had the following:

``` html
<div modal data-target="demoModal" ready="onReady" complete="onComplete" open="modalOpen">Open Modal</div>
```

Then in your controller, you would toggle the modal open or close like the following:

``` javascript
$scope.modalOpen = true; // opens modal
$scope.modalOpen = false; // closes modal
```
