### PR TITLE
Fixing bug with modal open attribute. 

### DIFF
--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -844,7 +844,7 @@
                     outDuration: "@",
                     ready: '&?',
                     complete: '&?',
-                    open: '=',
+                    open: '=?',
                     enableTabs: '@?'
                 },
                 link: function (scope, element, attrs) {


### PR DESCRIPTION
If it isn't optional and you don't provide something for angular to bind it with it will throw an error as it tries to change it to false when the modal is closed.
