### PR TITLE
Fixing issue where sideNav menu width attribute is being treated as a string

### DIFF
--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -159,7 +159,7 @@
                 },
                 link: function (scope, element, attrs) {
                     element.sideNav({
-                        menuWidth: (angular.isDefined(scope.menuwidth)) ? scope.menuwidth : undefined,
+                        menuWidth: (angular.isDefined(scope.menuwidth)) ? parseInt(scope.menuwidth, 10) : undefined,
                         edge: attrs.sidenav ? attrs.sidenav : "left",
                         closeOnClick: (angular.isDefined(scope.closeonclick)) ? scope.closeonclick == "true" : undefined
                     });


### PR DESCRIPTION
This causes the left property of the side menu to be miscalculated causing animation issues. It needs to be forced to be an integer. I noticed sidenav animations were super choppy and found it was because of this issue. 
