### PR TITLE
Adding a nouislider directive so you can use the range nouislider.

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
                             <li><a href="#input-field">Input-field</a></li>
                             <li><a href="#input-date">Input-date</a></li>
                             <li><a href="#select">Material select</a></li>
+                            <li><a href="#range">Range select</a></li>
                         </ul>
                     </div>
                 </li>
@@ -298,6 +299,16 @@ $scope.onStop = function () {
 &lt;select class="browser-default" ng-model="select.value2"&gt;
     &lt;option ng-repeat="value in select.choices"&gt;{{value}}&lt;/option&gt;
 &lt;/select&gt;</code></pre>
+        </div>
+
+        <div class="row" id="range">
+          <h2 class="header">Range - noUiSlider</h2>
+          <p>You can use the HTML5 range element without needing to use a directive or extra JavaScript. If you want to use the noUiSlider jQuery plugin that ships with materializecss, you'll need to include noUiSlider's JS and CSS file and use the <code class="language-markup" data-language="markup">nouislider</code> directive.
+<pre><code class="language-markup" ng-non-bindable>
+&lt;div nouislider ng-model="value" min="5" max="300"&gt;&lt;/div&gt;
+</code></pre>
+        <p>See <a href="http://refreshless.com/nouislider/slider-options/">noUiSlider's docs</a> for how to use it. Supported config options are: ngModel (required), min, max, step, connect, and tooltips.
+          </ul>
         </div>
 
         <div class="row" id="collapsible">

--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -1,5 +1,5 @@
 (function (angular) {
-    angular.module("ui.materialize", ["ui.materialize.ngModel", "ui.materialize.collapsible", "ui.materialize.toast", "ui.materialize.sidenav", "ui.materialize.material_select", "ui.materialize.dropdown", "ui.materialize.inputfield", "ui.materialize.input_date", "ui.materialize.tabs", "ui.materialize.pagination", "ui.materialize.pushpin", "ui.materialize.scrollspy", "ui.materialize.parallax","ui.materialize.modal", "ui.materialize.tooltipped",  "ui.materialize.slider", "ui.materialize.materialboxed", "ui.materialize.scrollFire"]);
+    angular.module("ui.materialize", ["ui.materialize.ngModel", "ui.materialize.collapsible", "ui.materialize.toast", "ui.materialize.sidenav", "ui.materialize.material_select", "ui.materialize.dropdown", "ui.materialize.inputfield", "ui.materialize.input_date", "ui.materialize.tabs", "ui.materialize.pagination", "ui.materialize.pushpin", "ui.materialize.scrollspy", "ui.materialize.parallax","ui.materialize.modal", "ui.materialize.tooltipped",  "ui.materialize.slider", "ui.materialize.materialboxed", "ui.materialize.scrollFire", "ui.materialize.nouislider"]);
 
     /*     example usage:
      <div scroll-fire="func('Scrolled', 2000)" ></scroll-fire>
@@ -1022,6 +1022,50 @@
                         element.materialbox();
                     });
 
+                }
+            };
+        }]);
+
+    /* example usage:
+    <div nouislider ng-model='value' min="0" max="100"></div>
+    */
+    angular.module("ui.materialize.nouislider", [])
+        .directive("nouislider", ["$timeout", function($timeout){
+            return {
+                restrict: 'A',
+                scope: {
+                    ngModel: '=',
+                    min: '@',
+                    max: '@',
+                    step: '@?',
+                    connect: '@?',
+                    tooltips: '@?'
+                },
+                link: function (scope, element, attrs) {
+                    $timeout(function () {
+                        noUiSlider.create(element[0], {
+                          	start: scope.ngModel || 0,
+                          	step: parseFloat(scope.step || 1),
+                            tooltips: angular.isDefined(scope.connect) ? scope.tooltips : undefined,
+                          	connect: angular.isDefined(scope.connect) ? scope.connect : 'lower',
+                          	range: {
+                          		'min': parseFloat(scope.min || 0),
+                          		'max': parseFloat(scope.max || 100),
+                          	},
+                            tooltips: true,
+                            format: wNumb({
+                              decimals: 0,
+                              encoder: function(a){
+                                  return Math.round(a * 100) / 100;
+                              }
+                            })
+                        });
+
+                        element[0].noUiSlider.on('update', function(values, input) {
+                          scope.ngModel = parseInt(values[0], 10);
+                          scope.$apply();
+                        });
+                    });
                 }
             };
         }]);

--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -1052,7 +1052,6 @@
                           		'min': parseFloat(scope.min || 0),
                           		'max': parseFloat(scope.max || 100),
                           	},
-                            tooltips: true,
                             format: wNumb({
                               decimals: 0,
                               encoder: function(a){


### PR DESCRIPTION
The HTML5 range slider works ok but has issues on mobile and doesn't support all the features the noUiSlider does that materializecss ships with. This directive adds basic support to use the noUiSlider instead of the HTML5 range slider. 
