### PR TITLE
Clockpicker function reference changed

### DIFF
--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -734,7 +734,7 @@
                 link: function (scope, element) {
                     $(element).addClass("timepicker");
                     if (!(scope.ngReadonly)) {
-                        element.clockpicker({
+                        element.pickatime({
                             default: (angular.isDefined(scope.default)) ? scope.default : '',
                             fromnow: (angular.isDefined(scope.fromnow)) ? scope.fromnow : 0,
                             donetext: (angular.isDefined(scope.donetext)) ? scope.donetext : 'Done',


### PR DESCRIPTION
The function `clockpicker` changed on the latest version of `materialize-clockpicker` to `pickatime`.
