### PR TITLE
Fix Modal to support new refactored version for v0.97.8

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "package.json"
   ],
   "dependencies": {
-    "materialize": "~0.97.7",
+    "materialize": "~0.97.8",
     "jquery": ">=2.1.1",
     "angular": ">=1.3.5"
   }

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/prism/0.0.1/prism.min.js"></script>
 
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.8/js/materialize.min.js"></script>
 
     <script type="text/javascript" src="src/angular-materialize.js"></script>
 
@@ -633,7 +633,7 @@ $scope.onStop = function () {
             In the below example, you can change the header of the modal through the input field. </p>
             <!-- Modal Trigger -->
             <div class="col">
-                <a class='btn' href='#demoModal' modal ready="readyCallback()" complete="completeCallback()" open="openModal">Show Modal</a>
+                <a class='btn' data-target='demoModal' modal ready="readyCallback()" complete="completeCallback()" open="openModal">Show Modal</a>
             </div>
             <div input-field  class="col s4">
                 <input type="text" ng-model="dummyInputs.modalInput">
@@ -656,7 +656,7 @@ $scope.onStop = function () {
         <div class="row">
                 <pre><code class="language-markup" ng-non-bindable>&lt;!-- Modal Trigger --&gt;
 &lt;div class="col"&gt;
-    &lt;a class='btn' href='#demoModal' modal&gt;Show Modal&lt;/a&gt;
+    &lt;a class='btn' data-target='demoModal' modal&gt;Show Modal&lt;/a&gt;
 &lt;/div&gt;
 &lt;!-- Modal Structure --&gt;
 &lt;div id="demoModal" class="modal"&gt;
@@ -677,7 +677,7 @@ $scope.onStop = function () {
         <div class="row">
           <pre><code class="language-markup" ng-non-bindable>&lt;!-- Modal Trigger --&gt;
 &lt;div class="col"&gt;
-    &lt;a class='btn' href='#demoModal' enable-tabs="true" modal&gt;Show Modal&lt;/a&gt;
+    &lt;a class='btn' data-target='demoModal' enable-tabs="true" modal&gt;Show Modal&lt;/a&gt;
 &lt;/div&gt;</code></pre>
         </div>
 

--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -1107,7 +1107,7 @@
 
     /*     example usage:
      <!-- Modal Trigger -->
-     <a class='btn' href='#demoModal' modal>show Modal</a>
+     <a class='btn' data-target='demoModal' modal>show Modal</a>
      <!-- Modal Structure -->
      <div id="demoModal" class="modal">
      <div class="modal-content">
@@ -1163,13 +1163,14 @@
                             ready: ready,
                             complete: complete,
                         };
-                        element.leanModal(options);
+                        modalEl.modal(options);
+                        element.modal(options);
 
                         // Setup watch for opening / closing modal programatically.
                         if (angular.isDefined(attrs.open) && modalEl.length > 0) {
                           scope.$watch('open', function(value, lastValue) {
                             if (!angular.isDefined(value)) { return; }
-                            (value === true) ? modalEl.openModal(options) : modalEl.closeModal();
+                            (value === true) ? modalEl.modal('open') : modalEl.modal('close');
                           });
                         }
                     });


### PR DESCRIPTION
Fix refactored function and module names as observable in this [commit](https://github.com/Dogfalo/materialize/commit/4984e2391fa7ce428d77910c2656835c021d11be):

- leanModal() -> modal()
- openModal() -> modal('open');
- closeModal() -> modal('close');

Add initialisation before opening, as the initialisation is no more performed automatically when calling openModal() [Source issue](https://github.com/Dogfalo/materialize/issues/3850). 
Compatibility with "href" doesn't work anymore. It opens the modal and redirect as a link. href tag has therefore been changed to data-target to remove any incoherence and unwanted behaviour.
