### PR TITLE
Rerender tooltip when data changes

### DIFF
--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -1234,16 +1234,6 @@
                         element.tooltip("remove");
                     });
 
-                    attrs.$observe('data-tooltip', function (value) {
-                        if (value === 'false' && rmDestroyListener !== Function.prototype) {
-                            element.tooltip("remove");
-                            rmDestroyListener();
-                            rmDestroyListener = Function.prototype;
-                        } else if (value !== 'false' && rmDestroyListener === Function.prototype) {
-                            init();
-                        }
-                    });
-
                     scope.$watch(function () {
                         return element.attr('data-tooltip');
                     }, function (oldVal, newVal) {

--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -1233,6 +1233,27 @@
                     element.on('$destroy', function() {
                         element.tooltip("remove");
                     });
+
+                    attrs.$observe('data-tooltip', function (value) {
+                        if (value === 'false' && rmDestroyListener !== Function.prototype) {
+                            element.tooltip("remove");
+                            rmDestroyListener();
+                            rmDestroyListener = Function.prototype;
+                        } else if (value !== 'false' && rmDestroyListener === Function.prototype) {
+                            init();
+                        }
+                    });
+
+                    scope.$watch(function () {
+                        return element.attr('data-tooltip');
+                    }, function (oldVal, newVal) {
+                        if (oldVal !== newVal && attrs.tooltippify !== 'false') {
+                            $timeout(function () {
+                               element.tooltip();
+                            });
+                        }
+                    });
+
                 }
             };
         }]);


### PR DESCRIPTION
If the value of data-tooltip changes, the tooltip text is not updated. You can observe this by passing an angular binding to the data-tooltip attribute and change this binding programmatically. The DOM will be updated with the new value of data-tooltip but the text that appears when you hover over the tooltip does not contain the new value.        

To solve this I have set up a watch for the data-tooltip attribute and I render the tooltip again once the value of this attribute changes.  