### PR TITLE
Fix autoresize init values

### DIFF
--- a/src/angular-materialize.js
+++ b/src/angular-materialize.js
@@ -524,6 +524,8 @@
                         element.find("> > .materialize-textarea").each(function () {
                             var that = $(this);
                             that.addClass("materialize-textarea");
+                            that.data("original-height", that.height());
+                            that.data("previous-length", that.val().length);
                             that.trigger("autoresize");
                             var model = that.attr("ng-model");
                             if (model) {


### PR DESCRIPTION
In the current master of `angular-materialize` + the current dependency to the `materialize-0.98.2`
textarea autoresize did not work. This is caused by required init values that are undefined.

Here are the changes made on `materialize` lib from the `0.97.8` and the `0.98.2` you could see what have changed : 
https://github.com/Dogfalo/materialize/compare/v0.97.8...v0.98.2#diff-338f03716a63d52eee0f79b4510d617cR156

Here are the lines that should init the `textarea` `onload` but due to lifecycle they are not set properly : 
https://github.com/Dogfalo/materialize/blob/138be0b945cc8e1ee24d76ab6c1240c3f3628565/js/forms.js#L175-L176

In the `materializecss` library, these 2 lines should init textarea values on dom content loaded, but due to angular lifecycle, these values are always `undefined` on dom content loaded, don't know exactly why because they are already encapsulated in a `$timeout`...

However, the changes made in this commit fixes the directive.

I didn't find a better way to do it.